### PR TITLE
Tab count for multiple windows when opening browser

### DIFF
--- a/background.html
+++ b/background.html
@@ -5,8 +5,10 @@
 function init() {
 	var count = 0;
 	// set up the initial tab count
-	chrome.tabs.getAllInWindow(null,function(tabs) {
-		count = tabs.length;
+	chrome.windows.getAll({"populate": true},function(windows) {
+		for( var i in windows ) {
+			count += windows[i].tabs.length;
+		}
 		chrome.browserAction.setBadgeText({text: "" + count});
 	});
 


### PR DESCRIPTION
Hi! 

This is a bit out of the blue. I just stumbled across your Tab Glutton extension, and fell in love with it. There's just one issue that makes it less than perfect for me, and that's that the initial tag count is inaccurate if there are multiple windows when opening the browser. 

This patch fixes it locally for me; offering it upstream for others to use.
